### PR TITLE
Fixed bugs that were introduced with the latest merge

### DIFF
--- a/app/Http/Controllers/DebugController.php
+++ b/app/Http/Controllers/DebugController.php
@@ -16,7 +16,11 @@ use Illuminate\Support\Carbon;
 class DebugController extends Controller
 {
     public function index(){
-        dd(json_encode(MaterialRequest::first()->raw_mats));
+        return response()->json([
+            'status' => 'error',
+            'message' => 'Request has already been submitted!'
+        ], 403);
+        dd(json_encode(MaterialRequest::first()));
         return view('debug');
     }
 

--- a/app/Http/Controllers/MatRequestController.php
+++ b/app/Http/Controllers/MatRequestController.php
@@ -125,6 +125,10 @@ class MatRequestController extends Controller
      */
     public function edit(MaterialRequest $materialrequest)
     {
+        if($materialrequest->mr_status == "Submitted"){
+            abort(403);
+        }
+
         $materials = ManufacturingMaterials::with('uom')->get();
         $stations = Station::get();
         $units = MaterialUOM::get();
@@ -145,6 +149,12 @@ class MatRequestController extends Controller
      */
     public function update(Request $request, MaterialRequest $materialrequest)
     {
+        if($materialrequest->mr_status == "Submitted"){
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Request has already been submitted!'
+            ], 403);
+        }
         $rules = [
             'item_code' => 'required|array',
             'item_code.*' => 'required|string|exists:env_raw_materials,item_code',
@@ -180,6 +190,7 @@ class MatRequestController extends Controller
                 'status' => 'success',
                 'update' => true,
                 'materialrequest' => $materialrequest,
+                'required_date' => $materialrequest->required_date->format("Y-m-d"),
                 'request' => $request->all(),
             ]);
         }catch(Exception $e){

--- a/app/Models/MaterialRequest.php
+++ b/app/Models/MaterialRequest.php
@@ -23,4 +23,8 @@ class MaterialRequest extends Model
         'required_date' => 'date',
         'request_date' => 'date'
     ];
+
+    public function raw_mats(){
+        return $this->hasMany(RequestedRawMat::class, 'request_id', 'request_id');
+    }
 }

--- a/public/js/materialrequest.js
+++ b/public/js/materialrequest.js
@@ -158,7 +158,7 @@ $('#mat-req').submit(function(){
                 // If the form's objective is to update, update the row
                 if(data.update){
                     let row = parentPane.find(`#mr-row-${data.materialrequest.id}`);
-                    row.children('td.mr-req-date').text(data.materialrequest.required_date);
+                    row.children('td.mr-req-date').text(data.required_date);
                     row.children('td.mr-purpose').text(data.materialrequest.purpose);
                     parentPane.find('.editModal').modal('hide');
                     parentPane.find('#mat-req').remove();
@@ -193,7 +193,7 @@ $(document).on('submit','#mr-submit',function(){
             row.children('td.mr-rq-status').prepend(
                 `<i class="fa fa-circle" aria-hidden="true" style="color:blue"></i> `
             );
-            row.find('.edit-mr-button').remove();
+            row.find('#edit-mr-button').remove();
             parentPane.find('#editModal').modal('hide');
             parentPane.find('#mat-req').remove();
         },

--- a/resources/views/modules/buying/materialReqmodules/edit_matreq_form.blade.php
+++ b/resources/views/modules/buying/materialReqmodules/edit_matreq_form.blade.php
@@ -35,7 +35,7 @@
                   <div class="form-group">
                     <label for="required_date">Required Date</label>
 
-                    <input value="{{ $materialRequest->required_date }}" type="date" required="true" name="required_date" id="required_date" class="form-control">
+                    <input value="{{ $materialRequest->required_date->format("Y-m-d") }}" type="date" required="true" name="required_date" id="required_date" class="form-control">
                   </div>
                 </div>
                 <div class="col-6">

--- a/resources/views/modules/buying/materialrequest.blade.php
+++ b/resources/views/modules/buying/materialrequest.blade.php
@@ -66,7 +66,7 @@
                         <i class="fa fa-circle" aria-hidden="true" style="color:{{ $color }}"></i>
                         {{ $mat_request->mr_status }}
                     </td>
-                    <td class="text-black-50 mr-req-date">{{ $mat_request->required_date }}</td>
+                    <td class="text-black-50 mr-req-date">{{ $mat_request->required_date->format("Y-m-d") }}</td>
                     <td class="text-black-50 mr-purpose">{{ $mat_request->purpose }}</td>
                     <td>
                     @if ($mat_request->mr_status == 'Draft')


### PR DESCRIPTION
- Material request edit form is viewable again, the fix involved re-defining the relationship of the materialrequest model with the materials involved in the request
- Fixed the way the required date is displayed/fetched; since a conversion to date object was declared in the materialrequest model it became required to format it if you don't wish to display the time and timezone as well